### PR TITLE
Enforces compliance of HttpCheck's assertion types

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ spec:
   interval: 1m
   retries: 3
   checks:
-    - type: status
+    - type: statusCode
       operator: equals
       value: 200
     - type: body
       operator: contains
       value: "OK"
-    - type: latency
+    - type: duration
       operator: lessThan
       value: 500ms
     - type: header

--- a/examples/http-check.yaml
+++ b/examples/http-check.yaml
@@ -13,13 +13,13 @@ spec:
   interval: 1m
   retries: 3
   checks:
-    - type: status
+    - type: statusCode
       operator: equals
       value: 200
     - type: body
       operator: contains
       value: "OK"
-    - type: latency
+    - type: duration
       operator: lessThan
       value: 500ms
     - type: header

--- a/src/synthetic_open_schema_model/v1beta1/http.py
+++ b/src/synthetic_open_schema_model/v1beta1/http.py
@@ -8,19 +8,19 @@ from ..base import BaseAssertion, Check, CheckSpec
 Headers = dict[str, str]
 
 
-class HttpExpectType(str, Enum):
+class HttpAssertionType(str, Enum):
     duration = "duration"
     size = "size"
     statusCode = "statusCode"
-    text = "text"
-    headers = "headers"
+    body = "body"
+    header = "header"
 
 
-class HttpExpect(BaseAssertion):
-    type: str
+class HttpAssertion(BaseAssertion):
+    type: HttpAssertionType
 
 
-HttpExpectList = List[HttpExpect]
+HttpAssertionList = List[HttpAssertion]
 
 
 class HttpCheckSpec(CheckSpec):
@@ -29,7 +29,7 @@ class HttpCheckSpec(CheckSpec):
     url: HttpUrl
     method: Optional[str] = "GET"
     headers: Optional[Headers] = {}
-    checks: Optional[HttpExpectList] = []
+    checks: HttpAssertionList
 
     @field_serializer("url")
     def serialize_url(self, url: HttpUrl) -> str:


### PR DESCRIPTION
HttpCheck assertion types weren't being validated, hence the validator was accepting any value as checks[].type.

This PR enforces validation and corrects the examples in both the examples directory and README
